### PR TITLE
Fixes a regex issue in cluster path

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_clusters.rb
+++ b/lib/fog/vsphere/requests/compute/list_clusters.rb
@@ -41,7 +41,7 @@ module Fog
 
         def cluster_path(cluster, datacenter_name)
           datacenter = find_raw_datacenter(datacenter_name)
-          cluster.pretty_path.gsub(/(#{datacenter_name}|#{datacenter.hostFolder.name})\//,'')
+          cluster.pretty_path.gsub(/(^#{datacenter_name}|#{datacenter.hostFolder.name})\//,'')
         end
       end
 


### PR DESCRIPTION
We have the following setup:

Datacenter: XYZ
  Folder: ABC - XYZ
    Cluster: Whatever

The regex tries to remove the datacenter name XYZ, but also remove part of the path which breaks the lookup of the resource pools later on.
By adding the ^ before the DC name in the regex, we ensure only that part is removed.